### PR TITLE
cargo: switch from failure to thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envsubst"
-version = "0.1.2-alpha.0"
+version = "0.2.0-alpha.0"
 description = "Variables substitution"
 license = "MIT/Apache-2.0"
 keywords = ["envsubst", "varsubst"]
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [dependencies]
-failure = "^0.1.5"
+thiserror = "^1.0"
 
 [package.metadata.release]
 sign-commit = true


### PR DESCRIPTION
The `failure` crate is not actively developed anymore, and the
newer `thiserror` works without leaking any additional type
to the public API. This switches to use the latter.