### PR TITLE
cargo: update all URLs to new location

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,7 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: envsubst
-Source: https://github.com/lucab/envsubst-rs
+Source: https://github.com/coreos/envsubst-rs
 
 Files: *
-Copyright: 2019, Project contributors
+Copyright: 2019-2022, Project contributors
 License: MIT or Apache-2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.2.1-alpha.0"
 description = "Variables substitution"
 license = "MIT/Apache-2.0"
 keywords = ["envsubst", "varsubst"]
-authors = ["Luca Bruno <lucab@debian.org>"]
-repository = "https://github.com/lucab/envsubst-rs"
+authors = ["Luca Bruno <lucab@lucabruno.net>"]
+repository = "https://github.com/coreos/envsubst-rs"
 edition = "2018"
 exclude = [
 ".gitignore",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # envsubst
 
-[![Build Status](https://travis-ci.org/lucab/envsubst-rs.svg?branch=master)](https://travis-ci.org/lucab/envsubst-rs)
 [![crates.io](https://img.shields.io/crates/v/envsubst.svg)](https://crates.io/crates/envsubst)
 [![Documentation](https://docs.rs/envsubst/badge.svg)](https://docs.rs/envsubst)
 


### PR DESCRIPTION
This updates all metadata in order to stop pointing to the old repository location.